### PR TITLE
added diskStats function and MIB

### DIFF
--- a/mibs/SUBAGENT-SHELL-DISKSTATS-MIB.txt
+++ b/mibs/SUBAGENT-SHELL-DISKSTATS-MIB.txt
@@ -1,0 +1,165 @@
+SUBAGENT-SHELL-DISKSTATS-MIB DEFINITIONS ::= BEGIN
+
+
+IMPORTS
+  MODULE-IDENTITY, enterprises, Counter64, Gauge32, Integer32 FROM SNMPv2-SMI
+  functionsEntry FROM SUBAGENT-SHELL-MIB
+  TimeStamp FROM SNMPv2-TC;
+
+SUBAGENT-SHELL-DISKSTATS MODULE-IDENTITY
+  LAST-UPDATED "201310281600Z"
+  ORGANIZATION "Example org"
+  CONTACT-INFO "iippolitov@gmail.com"
+  DESCRIPTION "SNMP SUBAGENT SHELL DISK STATS MIB"
+  ::= { functionsEntry 14 }
+
+  diskStatsCmdExecTime OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Function execution time."
+    ::= { SUBAGENT-SHELL-DISKSTATS 1 }
+
+  diskStatsCmdExecStatus OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Exec code."
+    ::= { SUBAGENT-SHELL-DISKSTATS 2 }
+
+  diskStatsTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF diskStatsTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION  ""
+    ::= { SUBAGENT-SHELL-DISKSTATS 3 }
+
+  diskStatsTableEntry OBJECT-TYPE 
+    SYNTAX      diskStatsTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current 
+    DESCRIPTION  "" 
+    INDEX      { diskStatsEntryIndex }
+    ::= { diskStatsTable 1 } 
+ 
+  diskStatsTableEntry ::= 
+    SEQUENCE { 
+        diskStatsIndex                 integer32,
+        diskStatsName                  OCTET STRING,
+        diskStatsReadsCompleted        integer32,
+        diskStatsReadsMerged           integer32,
+        diskStatsSectorsRead           integer32,
+        diskStatsMsSpentReading        integer32,
+        diskStatsWritesCompleted       integer32,
+        diskStatsWritesMerged          integer32,
+        diskStatsSectorsWritten        integer32,
+        diskStatsMsSpentWriting        integer32,
+        diskStatsIOInProgress          integer32,
+        diskStatsMsSpentInIO           integer32,
+        diskStatsWeightedMsSpentInIO   integer32,
+
+    } 
+
+    diskStatsIndex OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "A unique value, greater than zero, for each disk."
+    ::= { diskStatsTableEntry 1 }
+    
+    diskStatsName OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "block device name"
+    ::= { diskStatsTableEntry 2 }    
+
+    diskStatsReadsCompleted OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "This is the total number of reads completed successfully"
+    ::= { diskStatsTableEntry 3 }
+
+    diskStatsReadsMerged OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Reads and writes which are adjacent to each other may be merged for
+                efficiency.  Thus two 4K reads may become one 8K read before it is
+                ultimately handed to the disk, and so it will be counted (and queued)
+                as only one I/O.  This field lets you know how often this was done."
+    ::= { diskStatsTableEntry 4 }
+
+    diskStatsSectorsRead OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "This is the total number of sectors read successfully."
+    ::= { diskStatsTableEntry 5 }
+
+    diskStatsMsSpentReading OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "This is the total number of milliseconds spent by all reads (as
+                measured from __make_request() to end_that_request_last())."
+    ::= { diskStatsTableEntry 6 }
+
+    diskStatsWritesCompleted OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "This is the total number of writes completed successfully."
+    ::= { diskStatsTableEntry 7 }
+
+    diskStatsWritesMerged OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "As per diskStatsEntryReadsMerged"
+    ::= { diskStatsTableEntry 8 }
+
+    diskStatsSectorsWritten OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "This is the total number of sectors written successfully."
+    ::= { diskStatsTableEntry 9 }
+
+    diskStatsMsSpentWriting OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "This is the total number of milliseconds spent by all writes (as
+                measured from __make_request() to end_that_request_last())."
+    ::= { diskStatsTableEntry 10 }
+
+    diskStatsIOInProgress OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "The only field that should go to zero. Incremented as requests are
+                given to appropriate struct request_queue and decremented as they finish."
+    ::= { diskStatsTableEntry 11 }
+
+    diskStatsMsSpentInIO OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "This field increases so long as field 9 is nonzero."
+    ::= { diskStatsTableEntry 12 }
+
+    diskStatsWeightedMsSpentInIO OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "This field is incremented at each I/O start, I/O completion, I/O
+                merge, or read of these stats by the number of I/Os in progress
+                (field 9) times the number of milliseconds spent doing I/O since the
+                last update of this field.  This can provide an easy measure of both
+                I/O completion time and the backlog that may be accumulating."
+    ::= { diskStatsTableEntry 13 }
+    
+
+END

--- a/subagent-shell-base.functions
+++ b/subagent-shell-base.functions
@@ -495,4 +495,53 @@ sub pingStatMIB {
   return $r;
 }
 
+sub diskStatsMIB {
+  my $t = gettimeofday();
+  my $o=shift;
+  my $cfg=shift;
+  my $i=1;
+  my $r=0;
+
+  my $get_diskstats_command = $cfg->{'args'}[0]->{'command'} || 'cat /proc/diskstats';
+  my $match_re = $cfg->{'args'}[0]->{'match'} || '[hsv]d[a-z]+\\d*|c\\d+t\\d+d\\d+s\\d+$|cciss\/c\\d+d\\d+p\\d+|dm-\\d+';
+  
+  logMessage(LOG_DEBUG, "executing $get_diskstats_command");
+
+  foreach (`$get_diskstats_command 2>/dev/null`) {
+    # get contents of a file, split it and fill in the data
+    # pretty simple, read mib for description
+    # or look at https://www.kernel.org/doc/Documentation/iostats.txt
+    # to read the same with more details
+    my @block_devices_with_stats = split ;
+    next unless $#block_devices_with_stats == 13;
+    unless ( $block_devices_with_stats[2] =~ $match_re){
+        next;
+    }
+    logMessage(LOG_DEBUG, "Block device $block_devices_with_stats[2] matched against $match_re");
+    $$o{"diskStatsIndex.$i"}               = $i;
+    $$o{"diskStatsName.$i"}                = $block_devices_with_stats[2];
+    $$o{"diskStatsReadsCompleted.$i"}      = $block_devices_with_stats[3];
+    $$o{"diskStatsReadsMerged.$i"}         = $block_devices_with_stats[4];
+    $$o{"diskStatsSectorsRead.$i"}         = $block_devices_with_stats[5];
+    $$o{"diskStatsMsSpentReading.$i"}      = $block_devices_with_stats[6];
+    $$o{"diskStatsWritesCompleted.$i"}     = $block_devices_with_stats[7];
+    $$o{"diskStatsWritesMerged.$i"}        = $block_devices_with_stats[8];
+    $$o{"diskStatsSectorsWritten.$i"}      = $block_devices_with_stats[9]; 
+    $$o{"diskStatsMsSpentWriting.$i"}      = $block_devices_with_stats[10];
+    $$o{"diskStatsIOInProgress.$i"}        = $block_devices_with_stats[11];
+    $$o{"diskStatsMsSpentInIO.$i"}         = $block_devices_with_stats[12];
+    $$o{"diskStatsWeightedMsSpentInIO.$i"} = $block_devices_with_stats[13];
+
+    $i++;
+  }
+
+  # prepare return value and fill in some statistics of execution
+  $r = $? >> 8;
+  $$o{'diskStatsCmdExecStatus'} = $r;
+  $$o{'diskStatsCmdExecTime'} = sprintf('%.3f',scalar gettimeofday() - $t );
+
+  return $r;
+
+}
+
 return 1;

--- a/subagent-shell-functions-conf.xml
+++ b/subagent-shell-functions-conf.xml
@@ -9,6 +9,9 @@
 <function id="vmstatMIB"/>
 <function id="ip_conntrackMIB"/>
 <!--
+<function id="diskStatsMIB">
+  <args command="ssh localhost cat /proc/diskstats" match="sda\d+" />
+</function>
 <function id="pingStatMIB">
   <args host="www.google.com"/>
   <args host="8.8.8.8" count="5" options="-A"/>


### PR DESCRIPTION
I've created a function to parse /proc/diskstats file. There is a MIB file, a parsing function itself and a configuration example. By default, local file is parsed. I provided some basic features like "arbitrary command execution" and "block device filtering by name".
"arbitrary command execution" means that you can use any commands (e.g. self-written script) which produces 14 fielded output (like diskstats file). "command" option is used to configure arbitrary command.
"block device filtering by name" means that only some output is processed. A line is processed if its second field matches an RE. RE can be set using "match" option.
Any option can be omitted. Only one copy of arguments (the first one) will be used.
