### PR TITLE
Snmp agg

### DIFF
--- a/mibs/SUBAGENT-SHELL-ASV-MIB.txt
+++ b/mibs/SUBAGENT-SHELL-ASV-MIB.txt
@@ -1,0 +1,142 @@
+SUBAGENT-SHELL-ASV-MIB DEFINITIONS ::= BEGIN
+
+
+IMPORTS
+  MODULE-IDENTITY, enterprises, Counter64, Gauge32, Integer32 FROM SNMPv2-SMI
+  functionsEntry FROM SUBAGENT-SHELL-MIB
+  TimeStamp FROM SNMPv2-TC;
+
+SUBAGENT-SHELL-ASV MODULE-IDENTITY
+  LAST-UPDATED "201604051600Z"
+  ORGANIZATION "Example org"
+  CONTACT-INFO "iippolitov@gmail.com"
+  DESCRIPTION "SNMP SUBAGENT SHELL AGGREGATE SNMP VALUES MIB"
+  ::= { functionsEntry 93 }
+
+  asvCmdExecTime OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Function execution time."
+    ::= { SUBAGENT-SHELL-ASV 1 }
+
+  asvCmdExecStatus OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Exec code."
+    ::= { SUBAGENT-SHELL-ASV 2 }
+  
+  asvTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF asvTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION  ""
+    ::= { SUBAGENT-SHELL-ASV 3 }
+
+  asvTableEntry OBJECT-TYPE 
+    SYNTAX      asvTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current 
+    DESCRIPTION  "" 
+    INDEX      { asvEntryIndex }
+    ::= { asvTable 1 } 
+ 
+  asvTableEntry ::= 
+    SEQUENCE { 
+        asvEntryIndex   Integer32,
+	asvOid		OCTET STRING,
+	asvOidMin	OCTET STRING,
+	asvOidMax	OCTET STRING,
+	asvOidAvg	OCTET STRING,
+	asvOidSum	OCTET STRING,
+        asvOidTable	asvOidTableEntry
+    } 
+
+  asvEntryIndex OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "INDEX of the table"
+    ::= { asvTableEntry 1 }
+
+  asvOid OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "An OID to aggregate"
+    ::= { asvTableEntry 2 }
+
+  asvOidMin OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "The minimum value of all for this OID"
+    ::= { asvTableEntry 3 }
+
+  asvOidMax OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "The maximum value of all for this OID"
+    ::= { asvTableEntry 4 }
+
+   asvOidAvg OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "An average value for this OID"
+    ::= { asvTableEntry 5 }
+
+   asvOidSum OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Sum for all values for this OID"
+    ::= { asvTableEntry 6 }
+ 
+  asvOidTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF asvOidTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION  ""
+    ::= { asvTableEntry 7 }
+
+  asvOidTableEntry OBJECT-TYPE 
+    SYNTAX      asvOidTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current 
+    DESCRIPTION  "" 
+    INDEX      { asvHostIndex }
+    ::= { asvOidTable 1 } 
+
+  asvOidTableEntry ::=
+    SEQUENCE {
+        asvHostIndex                Integer32,
+        asvHostName                 OCTET STRING,
+        asvHostValue		OCTET STRING
+    }
+
+
+    asvHostIndex OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "A unique value, greater than zero, for each host"
+    ::= { asvOidTableEntry 1 }
+    
+    asvHostName OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Host name"
+    ::= { asvOidTableEntry 2 }    
+
+    asvHostValue    OBJECT-TYPE
+    SYNTAX      OCTET STRING
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "A value from a host"
+    ::= { asvOidTableEntry 3 }
+
+END

--- a/subagent-shell-base.functions
+++ b/subagent-shell-base.functions
@@ -721,7 +721,7 @@ sub asvMib {
                                                   Version => "v2c",
                                                   Timeout => $a->{'timeout'} || 1
                                             );
-      my $result = $session->get_request(Varbindlist => [$oid]);
+      my $result = $session->get_request(Varbindlist => [$oid]) if (defined $session);
       if (!defined $result) {
         logMessage(LOG_WARNING, "Got no result from $host:".$session->error() );
         $r=1;
@@ -729,12 +729,19 @@ sub asvMib {
         $host_num++;
         $val = $result->{$oid}; 
         logMessage(LOG_DEBUG, "Got '$val' from $host");
-        my $difference = $val - ($asvStats->{$oid}->{$host} || 0) ;
+
+        # difference is either the value itself or difference with previous value
+        my $difference = $val - ($asvStats->{$oid}[$i]->{$host} || 0) ;
+        # if $val is less than 0, this still works as intended
         if ($difference < 0) { $difference = $val; }
         $min = defined $min && $min < $difference ? $min : $difference;
         $max = defined $max && $max > $difference ? $max : $difference;
         $sum = $sum + $difference;
-        $asvStats->{$oid}->{$host} = $val;
+
+        # if the oid is marked as gauge don't calculate differences for it. 
+        # use difference only for 'derive' like things (as per rrd)
+        if (! (defined $a->{'gauge'} && $a->{'gauge'} == "true")) {$asvStats->{$oid}[$i]->{$host} = $val};
+
         $$o{"asvHostIndex.$i.$host_num"} = $host_num;
         $$o{"asvHostName.$i.$host_num"} = $host;
         $$o{"asvHostValue.$i.$host_num"} = $val;
@@ -747,7 +754,6 @@ sub asvMib {
     $$o{"asvOidMax.$i"} = $max;
     $$o{"asvOidSum.$i"} = $sum;
     $$o{"asvOidAvg.$i"} = $sum/$host_num;
-    undef $min, $max;
 
   }
   $$o{'asvCmdExecStatus'} = $r;

--- a/subagent-shell-base.functions
+++ b/subagent-shell-base.functions
@@ -1,3 +1,4 @@
+# vi:syntax=diff
 use strict;
 use warnings;
 use Sys::Syslog qw(:standard :macros);
@@ -346,51 +347,26 @@ sub dnsLookUpMIB {
   my $cmd="/usr/bin/host -W $config->{'cmd_timeout'}";
   my $i=1;
   my $r=0;
-  my @nameservers;
   my $t=gettimeofday();
 
   foreach my $a (@{$cfg->{'args'}}) {
-    my $srv='';
+    my $lookup_ips = '';
     my $ts=gettimeofday();
-    if ( ! $a->{'fqdn'}) {$a->{'fqdn'} = hostname};
-    
-    if (defined($a->{'servers'})) {
-      if ($a->{'servers'} =~/^\s*$/ ){  
-        #get nameservers
-        @nameservers = (); 
-        open (ERC, '/etc/resolv.conf');
-        while (<ERC>) {
-          chomp;
-          if (/nameserver (\S+)$/) {
-            push @nameservers,$1; 
-          }
-        }
-        close (ERC); 
-      } else {
-        @nameservers = split(/[,\s]*/,$a->{'servers'});
+    foreach (`$cmd $a->{'fqdn'}`) {
+      chomp;
+      my $s=$_;
+      if ( /has address/ ) {
+        $lookup_ips .=  (split / /,$s)[3] . ',';
       }
-    } 
-    #next 'foreach' will be done at least once for each fqdn
-    if ($#nameservers < 0) {push @nameservers, ' '};
-    foreach $srv (@nameservers) {
-      my $lookup_ips = '';
-      foreach (`$cmd $a->{'fqdn'} $srv`) {
-        chomp;
-        my $s=$_;
-        if ( /has address/ ) {
-          $lookup_ips .=  (split / /,$s)[3] . ',';
-        }
-      }
-      my $lookup_r = $? >> 8;
-      $$o{"dnsIndex.$i"} = $i;
-      $$o{"dnsNameLookUp.$i"} = $a->{'fqdn'}; $$o{"dnsNameLookUp.$i"} .= " at $srv" if ($srv =~ /\S/);
-      $$o{"dnsNameResolvedIp.$i"} = $lookup_ips;
-      $$o{"dnsLookUpExecTime.$i"} = sprintf('%.3f',scalar gettimeofday() - $ts);
-      $$o{"dnsLookUpExecStatus.$i"} = $lookup_r;
-      $r = $lookup_r if $lookup_r;
-      $i++;
-      
     }
+    my $lookup_r = $? >> 8;
+    $$o{"dnsIndex.$i"} = $i;
+    $$o{"dnsNameLookUp.$i"} = $a->{'fqdn'};
+    $$o{"dnsNameResolvedIp.$i"} = $lookup_ips;
+    $$o{"dnsLookUpExecTime.$i"} = sprintf('%.3f',scalar gettimeofday() - $ts);
+    $$o{"dnsLookUpExecStatus.$i"} = $lookup_r;
+    $r = $lookup_r if $lookup_r;
+    $i++;
   }
   $$o{'dnsLookUpFuncExecTime'} = sprintf('%.3f',scalar gettimeofday() - $t);
   $$o{'dnsLookUpFuncExecStatus'} = $r;
@@ -709,6 +685,73 @@ sub diskStatsMIB {
   $r = $? >> 8;
   $$o{'diskStatsCmdExecStatus'} = $r;
   $$o{'diskStatsCmdExecTime'} = sprintf('%.3f',scalar gettimeofday() - $t );
+
+  return $r;
+
+}
+
+my $asvStats;
+
+sub asvMib {
+  use Net::SNMP;
+  my $t = gettimeofday();
+  my $o=shift;
+  my $cfg=shift;
+  my $i=0;
+  my $r=0;
+
+  foreach my $a ( @{$cfg->{'args'}} ) {
+    $i++;
+    my $oid = $a->{'oid'};
+    my @hosts = glob $a->{'hosts'};
+    my $min;
+    my $max;
+    my $sum=0;
+    my $host_num=0;
+
+    $$o{"asvEntryIndex.$i"} = $i;
+    $$o{"asvOid.$i"} = $oid;
+   
+    logMessage(LOG_DEBUG, "fetching data for $oid from @hosts");
+
+    foreach my $host (@hosts){
+      my $val;
+      my ($session, $error) = Net::SNMP->session( Hostname => $host,
+                                                  Community => $a->{'community'} || 'public',
+                                                  Version => "v2c",
+                                                  Timeout => $a->{'timeout'} || 1
+                                            );
+      my $result = $session->get_request(Varbindlist => [$oid]);
+      if (!defined $result) {
+        logMessage(LOG_WARNING, "Got no result from $host:".$session->error() );
+        $r=1;
+      } else {
+        $host_num++;
+        $val = $result->{$oid}; 
+        logMessage(LOG_DEBUG, "Got '$val' from $host");
+        my $difference = $val - ($asvStats->{$oid}->{$host} || 0) ;
+        if ($difference < 0) { $difference = $val; }
+        $min = defined $min && $min < $difference ? $min : $difference;
+        $max = defined $max && $max > $difference ? $max : $difference;
+        $sum = $sum + $difference;
+        $asvStats->{$oid}->{$host} = $val;
+        $$o{"asvHostIndex.$i.$host_num"} = $host_num;
+        $$o{"asvHostName.$i.$host_num"} = $host;
+        $$o{"asvHostValue.$i.$host_num"} = $val;
+        logMessage(LOG_DEBUG, "Difference with old is $difference");
+      }
+      $session->close();
+    }
+
+    $$o{"asvOidMin.$i"} = $min;
+    $$o{"asvOidMax.$i"} = $max;
+    $$o{"asvOidSum.$i"} = $sum;
+    $$o{"asvOidAvg.$i"} = $sum/$host_num;
+    undef $min, $max;
+
+  }
+  $$o{'asvCmdExecStatus'} = $r;
+  $$o{'asvCmdExecTime'} = sprintf('%.3f',scalar gettimeofday() - $t );
 
   return $r;
 

--- a/subagent-shell-base.functions
+++ b/subagent-shell-base.functions
@@ -336,26 +336,51 @@ sub dnsLookUpMIB {
   my $cmd="/usr/bin/host -W $config->{'cmd_timeout'}";
   my $i=1;
   my $r=0;
+  my @nameservers;
   my $t=gettimeofday();
 
   foreach my $a (@{$cfg->{'args'}}) {
-    my $lookup_ips = '';
+    my $srv='';
     my $ts=gettimeofday();
-    foreach (`$cmd $a->{'fqdn'}`) {
-      chomp;
-      my $s=$_;
-      if ( /has address/ ) {
-        $lookup_ips .=  (split / /,$s)[3] . ',';
+    if ( ! $a->{'fqdn'}) {$a->{'fqdn'} = hostname};
+    
+    if (defined($a->{'servers'})) {
+      if ($a->{'servers'} =~/^\s*$/ ){  
+        #get nameservers
+        @nameservers = (); 
+        open (ERC, '/etc/resolv.conf');
+        while (<ERC>) {
+          chomp;
+          if (/nameserver (\S+)$/) {
+            push @nameservers,$1; 
+          }
+        }
+        close (ERC); 
+      } else {
+        @nameservers = split(/[,\s]*/,$a->{'servers'});
       }
+    } 
+    #next 'foreach' will be done at least once for each fqdn
+    if ($#nameservers < 0) {push @nameservers, ' '};
+    foreach $srv (@nameservers) {
+      my $lookup_ips = '';
+      foreach (`$cmd $a->{'fqdn'} $srv`) {
+        chomp;
+        my $s=$_;
+        if ( /has address/ ) {
+          $lookup_ips .=  (split / /,$s)[3] . ',';
+        }
+      }
+      my $lookup_r = $? >> 8;
+      $$o{"dnsIndex.$i"} = $i;
+      $$o{"dnsNameLookUp.$i"} = $a->{'fqdn'}; $$o{"dnsNameLookUp.$i"} .= " at $srv" if ($srv =~ /\S/);
+      $$o{"dnsNameResolvedIp.$i"} = $lookup_ips;
+      $$o{"dnsLookUpExecTime.$i"} = sprintf('%.3f',scalar gettimeofday() - $ts);
+      $$o{"dnsLookUpExecStatus.$i"} = $lookup_r;
+      $r = $lookup_r if $lookup_r;
+      $i++;
+      
     }
-    my $lookup_r = $? >> 8;
-    $$o{"dnsIndex.$i"} = $i;
-    $$o{"dnsNameLookUp.$i"} = $a->{'fqdn'};
-    $$o{"dnsNameResolvedIp.$i"} = $lookup_ips;
-    $$o{"dnsLookUpExecTime.$i"} = sprintf('%.3f',scalar gettimeofday() - $ts);
-    $$o{"dnsLookUpExecStatus.$i"} = $lookup_r;
-    $r = $lookup_r if $lookup_r;
-    $i++;
   }
   $$o{'dnsLookUpFuncExecTime'} = sprintf('%.3f',scalar gettimeofday() - $t);
   $$o{'dnsLookUpFuncExecStatus'} = $r;

--- a/subagent-shell-functions-conf.xml
+++ b/subagent-shell-functions-conf.xml
@@ -9,6 +9,9 @@
 <function id="vmstatMIB"/>
 <function id="ip_conntrackMIB"/>
 <!--
+<function id="asvMib">
+  <args oid=".1.3.6.1.2.1.25.1.6.0" community="public" hosts="127.0.0.{1,2,3,4,5}" />
+</function>
 <function id="diskStatsMIB">
   <args command="ssh localhost cat /proc/diskstats" match="sda\d+" />
 </function>


### PR DESCRIPTION
This function can be used to calculate common aggregate functions for values gathered from several hosts via snmp.
If a value has 'derive' or 'counter' semantics the function will calculate a difference with previous value for each host and make the result value positive.
If a value is used as a 'gauge' than no difference is calculated and raw data is used.